### PR TITLE
Less left-padding for buttons in channel sidebar

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -475,6 +475,11 @@ kbd{
     /* margin: auto; */
 }
 
+/* With thinner channel sidebar, we need to have less padding to the left for buttons */
+#footer {
+    padding-left: 5px;
+}
+
 /* ****** Public css mods ****** */
 /* Better CSS box */
 #user-specified-css-input {


### PR DESCRIPTION
With thinner channel sidebar, we need to have less padding to the left for buttons. If not the log-out button will show.