### PR TITLE
Monospace font for server MOTD

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -728,4 +728,6 @@ kbd {
 }
 
 /* Monospace font for server MOTD, since ASCII require this */
-.msg.motd {font-family: Monospace;}
+.msg.motd {
+    font-family: Monospace;
+}

--- a/mininapse.css
+++ b/mininapse.css
@@ -726,3 +726,6 @@ kbd {
 #form #submit {
     color: rgb(197, 193, 193);
 }
+
+/* Monospace font for server MOTD, since ASCII require this */
+.msg.motd {font-family: Monospace;}


### PR DESCRIPTION
Several networks use ASCII in their server MOTD. To see correct ASCII art you usualy need Monospace font.