### PR TITLE
Unhid add channel and close channel buttons

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -215,9 +215,6 @@ Authors:
 #sidebar .logo,
 #sidebar .logo-inverted,
 #sidebar .chan::before,
-.add-channel,
-.add-channel-tooltip,
-#sidebar .chan.channel .close,
 .not-secure-tooltip,
 .not-secure-icon {
     display: none;


### PR DESCRIPTION
The add channel and close channel buttons are hidden.
Removed the offending CSS for now that will enable them again.