### PR TITLE
Adjust .btn colours

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -157,6 +157,16 @@ Authors:
     color: var(--link-color);
 }
 
+.btn{
+    border-color: var(--link-color);
+    color: var(--link-color);
+}
+
+.btn:disabled, .btn:focus, .btn:hover {
+    background: var(--window-bg-color);
+    color: var(--dim-color);
+}
+
 #viewport .lt:hover,
 #viewport .rt:hover,
 #chat button.menu:hover,


### PR DESCRIPTION
This adjusts them to no longer be green.
Also affects the loading message when browsing to channels without any loaded content

![image](https://user-images.githubusercontent.com/12771982/53237171-22774600-36ea-11e9-813b-30e64a058d08.png)

Styles formatting match the default style, but only changes colours