### PR TITLE
Remove box-shadow on input:focus

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -280,7 +280,7 @@ input,
 .btn:focus,
 .input:focus {
     border-color: rgba(0, 0, 0, 0) !important;
-    box-shadow: 0 0 0 3px var(--window-bg-color);
+    box-shadow: 0 0 0 1px var(--highlight-border-color);
 }
 
 .input::placeholder,

--- a/mininapse.css
+++ b/mininapse.css
@@ -280,7 +280,7 @@ input,
 .btn:focus,
 .input:focus {
     border-color: rgba(0, 0, 0, 0) !important;
-    box-shadow: 0 0 0 0px var(--highlight-border-color);
+    box-shadow: 0 0 0 3px var(--window-bg-color);
 }
 
 .input::placeholder,

--- a/mininapse.css
+++ b/mininapse.css
@@ -280,7 +280,7 @@ input,
 .btn:focus,
 .input:focus {
     border-color: rgba(0, 0, 0, 0) !important;
-    box-shadow: 0 0 0 3px var(--highlight-border-color);
+    box-shadow: 0 0 0 0px var(--highlight-border-color);
 }
 
 .input::placeholder,


### PR DESCRIPTION
There's no box-shadows on input fields as jump-to and where you type text. It looks incosistent.

I suggest removing box-shadow on all input fields.