### PR TITLE
Make focus outlight slightly thinner

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -280,7 +280,7 @@ input,
 .btn:focus,
 .input:focus {
     border-color: rgba(0, 0, 0, 0) !important;
-    box-shadow: 0 0 0 2px var(--highlight-border-color);
+    box-shadow: 0 0 0 1.5px var(--highlight-border-color);
 }
 
 .input::placeholder,

--- a/mininapse.css
+++ b/mininapse.css
@@ -280,7 +280,7 @@ input,
 .btn:focus,
 .input:focus {
     border-color: rgba(0, 0, 0, 0) !important;
-    box-shadow: 0 0 0 3px var(--highlight-border-color);
+    box-shadow: 0 0 0 2px var(--highlight-border-color);
 }
 
 .input::placeholder,


### PR DESCRIPTION
1px (alternative, too thin for my taste):
![grafik](https://user-images.githubusercontent.com/2185527/75681862-b7fdcc00-5c94-11ea-8b18-9abf3d2f6f62.png)
1.5px:
![grafik](https://user-images.githubusercontent.com/2185527/75682024-03b07580-5c95-11ea-830d-7138c56d4a65.png)
2px (proposed):
![grafik](https://user-images.githubusercontent.com/2185527/75681801-9866a380-5c94-11ea-8b87-26e90d5c95a4.png)
3px (current):
![grafik](https://user-images.githubusercontent.com/2185527/75681830-a87e8300-5c94-11ea-98c2-0cf4276f9098.png)