### PR TITLE
Fix background colour on mentions popup

### DIFF
--- a/mininapse.css
+++ b/mininapse.css
@@ -444,3 +444,8 @@ code {
     -webki-backdrop-filter: blur(2px); /* edge combat, no ff or IE, sorry guys */
     backdrop-filter: blur(2px);
 }
+
+/* Mentions popup */
+.mentions-popup .msg .content {
+    background-color: var(--dark-bg-color);
+}


### PR DESCRIPTION
Makes these actually readable, it currently fails guidelines for accessible text

Before:
![image](https://user-images.githubusercontent.com/12771982/90948352-0d1add80-e481-11ea-96e2-34a2d4a06a12.png)
After:
![image](https://user-images.githubusercontent.com/12771982/90948355-1015ce00-e481-11ea-906c-1db714a05cf2.png)